### PR TITLE
Android auth

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -126,6 +126,7 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-touch-id-android')
     compile project(':react-native-device-info')
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"

--- a/android/app/src/main/java/com/rocknative/MainApplication.java
+++ b/android/app/src/main/java/com/rocknative/MainApplication.java
@@ -3,6 +3,8 @@ package com.rocknative;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
+import com.github.ajalt.reprint.core.Reprint; // touchid
+import co.eleken.react_native_touch_id_android.FingerprintPackage; // touchid
 import com.learnium.RNDeviceInfo.RNDeviceInfo;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
@@ -24,6 +26,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
+            new FingerprintPackage(),
             new RNDeviceInfo()
       );
     }
@@ -38,5 +41,6 @@ public class MainApplication extends Application implements ReactApplication {
   public void onCreate() {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
+    Reprint.initialize(this); // touchid
   }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,5 +20,6 @@ allprojects {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
         }
+        maven { url "https://jitpack.io" } // for android touchid
     }
 }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'RockNative'
+include ':react-native-touch-id-android'
+project(':react-native-touch-id-android').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-touch-id-android/android')
 include ':react-native-device-info'
 project(':react-native-device-info').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-device-info/android')
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react-native": "0.42.3",
     "react-native-device-info": "^0.10.2",
     "react-native-touch-id": "^3.0.0",
+    "react-native-touch-id-android": "0.0.5",
     "react-native-windows": "0.42.0",
     "react-router": "4.1.1",
     "react-router-dom": "4.1.1",

--- a/src/blocks/Biometrics/biometrics.android.js
+++ b/src/blocks/Biometrics/biometrics.android.js
@@ -1,0 +1,14 @@
+// @flow
+
+/*
+  NOTE: react_native_touch_id_android needs a couple changes to the /android/build.gradle
+  and /android/app/src/main/java/com/rocknative/MainApplication.java file. If either of these
+  get changed, bad things may happen. Just so you know :)
+*/
+
+import auth from "react-native-touch-id-android";
+
+auth.isSupported = auth.isSensorAvailable;
+auth.authenticate = auth.requestTouch;
+
+export default auth;

--- a/src/blocks/Biometrics/biometrics.ios.js
+++ b/src/blocks/Biometrics/biometrics.ios.js
@@ -1,41 +1,4 @@
 // @flow
 import auth from "react-native-touch-id";
-import React from "react";
-import { Button } from "react-native";
-import { withState, lifecycle } from "recompose";
 
-export const supportsBiometrics = (): Promise<boolean> =>
-  auth.isSupported().then(() => true).catch(() => false);
-
-// XXX later: need to save the results of this somewhere
-export const authWithBiometrics = (reason: string) => async () =>
-  await auth.authenticate(reason);
-
-/*HOCs for the auth components to use*/
-
-export const withSupportedState = withState(
-  "supportsBiometrics",
-  "setSupport",
-  false,
-);
-export const withLifecycle = lifecycle({
-  componentDidMount() {
-    supportsBiometrics()
-      .then(supported => this.props.setSupport(Boolean(supported)))
-      .catch(() => this.props.setSupport(false));
-  },
-});
-
-const UnwrappedAuth = ({
-  supportsBiometrics,
-}: {
-  supportsBiometrics: boolean,
-}) =>
-  supportsBiometrics
-    ? <Button
-        title="Authenticate"
-        onPress={authWithBiometrics("login to Rock")}
-      />
-    : null;
-
-export const Auth = withSupportedState(withLifecycle(UnwrappedAuth));
+export default auth;

--- a/src/blocks/Biometrics/biometrics.web.js
+++ b/src/blocks/Biometrics/biometrics.web.js
@@ -1,1 +1,4 @@
-
+export default {
+  isSupported: () => Promise.resolve(false),
+  authenticate: () => Promise.resolve(false),
+};

--- a/src/blocks/Biometrics/index.js
+++ b/src/blocks/Biometrics/index.js
@@ -1,3 +1,44 @@
-import { supportsBiometrics, authWithBiometrics, Auth } from "./biometrics";
+// @flow
+import React from "react";
+import { Button } from "react-native";
+import { withState, lifecycle } from "recompose";
 
-export { supportsBiometrics, authWithBiometrics, Auth };
+// XXX will load the platform-specific utils
+import auth from "./biometrics";
+
+// XXX the platform-agnostic auth methods
+export const supportsBiometrics = (): Promise<boolean> =>
+  auth.isSupported().then(() => true).catch(() => false);
+
+// XXX later: need to save the results of this somewhere
+export const authWithBiometrics = (reason?: string) => async () =>
+  await auth.authenticate(reason);
+
+/*HOCs for the Auth component to use*/
+export const withSupportedState = withState(
+  "supportsBiometrics",
+  "setSupport",
+  false,
+);
+export const withLifecycle = lifecycle({
+  componentDidMount() {
+    supportsBiometrics()
+      .then(supported => this.props.setSupport(Boolean(supported)))
+      .catch(() => this.props.setSupport(false));
+  },
+});
+
+export const UnwrappedAuth = ({
+  supportsBiometrics,
+}: {
+  supportsBiometrics: boolean,
+}) =>
+  supportsBiometrics
+    ? <Button
+        title="Authenticate"
+        onPress={authWithBiometrics("login to Rock")}
+      />
+    : null;
+
+export const Auth = withSupportedState(withLifecycle(UnwrappedAuth));
+export default Auth;

--- a/src/data/graphql/networkInterface.js
+++ b/src/data/graphql/networkInterface.js
@@ -2,9 +2,16 @@
 import { createBatchingNetworkInterface } from "react-apollo";
 import { platform, bundleId, version } from "./util";
 
+/*
+  NOTE: Since Android is run in an emulator instead of a simulator, localhost
+  is the address of the emulated device, not the dev machine. We have to use 10.0.2.2
+  for the dev machine.
+*/
+const isAndroid = platform() === "android";
+
 export default () =>
   createBatchingNetworkInterface({
-    uri: "http://localhost:3000/graphql",
+    uri: `http://${isAndroid ? "10.0.2.2" : "localhost"}:3000/graphql`,
     batchInterval: 10,
   }).use([
     {


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- added android touchId support
- moved functions/components around to be platform agnostic

**Note**: Right now there is no UI that asks for a touch on android. Once you hit the authenticate button, the device waits for a touch, but doesn't have a default alert like ios does to ask. When passed a touch, it still works.

